### PR TITLE
changed validation check URL to use .../forks

### DIFF
--- a/tasks/check_github_creds.sh
+++ b/tasks/check_github_creds.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if curl --user "${PT_username}":"${PT_password}" -i -s -X GET \
-  https://api.github.com/repos/puppetlabs-seteam/workshop-control-repo/hooks | grep "HTTP/1.1 200 OK"
+  https://api.github.com/repos/puppetlabs-seteam/workshop-control-repo/forks | grep "HTTP/1.1 200 OK"
 then
   echo "Credentials verification succeeded"
 else


### PR DESCRIPTION
I have enough permissions to fork the repo to build the workshop, however I do not have access to the settings (nor specifically the .../hooks URL endpoint).
The ".../forks" endpoint is likely a better check for required access, hence this change.