### PR TITLE
Support for Bolt 1.16

### DIFF
--- a/plans/init.pp
+++ b/plans/init.pp
@@ -28,14 +28,14 @@ plan workshop_deploy(
 
   wait_until_available($nodes, description => 'Waiting up to 5 minutes until AWS instance becomes available...', wait_time => 300, retry_interval => 15)
 
-  run_task(workshop_deploy::check_github_creds, $nodes, 'Checking Github credentials...', 'username' => $github_user, 'password' => $github_pwd)
-  run_task(workshop_deploy::download_pe, $nodes, 'Download latest version of Puppet Enterprise...')
-  run_task(workshop_deploy::prep_pe, $nodes, 'Run preparatory steps for Puppet Enterprise...', 'username' => $github_user, 'admin_pwd' => $pe_admin_pwd)
+  run_task(workshop_deploy::check_github_creds, $nodes, 'Checking Github credentials...', 'username' => $github_user, 'password' => $github_pwd, '_run_as' => 'root')
+  run_task(workshop_deploy::download_pe, $nodes, 'Download latest version of Puppet Enterprise...', '_run_as' => 'root')
+  run_task(workshop_deploy::prep_pe, $nodes, 'Run preparatory steps for Puppet Enterprise...', 'username' => $github_user, 'admin_pwd' => $pe_admin_pwd, '_run_as' => 'root')
 
   apply_prep($nodes)
 
   notice('Installing Prereqs...')
-  apply($nodes){
+  apply($nodes, '_run_as' => 'root'){
     $packages = [
       'wget',
       'nano',
@@ -69,20 +69,20 @@ plan workshop_deploy(
     }
   }
 
-  run_command("hostnamectl set-hostname ${pe_name}", $nodes, 'Set Hostname...')
+  run_command("hostnamectl set-hostname ${pe_name}", $nodes, 'Set Hostname...', '_run_as' => 'root')
 
   notice('Updating /etc/hosts...')
-  apply($nodes){
+  apply($nodes, '_run_as' => 'root'){
     host { $pe_name:
       ensure => present,
       ip     => $facts['ipaddress']
     }
   }
 
-  run_task(workshop_deploy::generate_keys, $nodes, 'Generate SSH keys...')
-  
+  run_task(workshop_deploy::generate_keys, $nodes, 'Generate SSH keys...', '_run_as' => 'root')
+
   notice('Generating Control Repo student prep scripts...')
-  apply($nodes){
+  apply($nodes, '_run_as' => 'root'){
     file { '/root/prep.ps1':
       ensure  => file,
       content => epp('workshop_deploy/prep_ps1.epp', { 'github_user' => $github_user })
@@ -92,16 +92,16 @@ plan workshop_deploy(
       content => epp('workshop_deploy/prep_sh.epp', { 'github_user' => $github_user })
     }
   }
-  
-  run_task(workshop_deploy::setup_control_repo, $nodes, 'Setting up Control Repo...', 'username' => $github_user, 'password' => $github_pwd)
 
-  run_task(workshop_deploy::firewall_ports, $nodes, 'Open firewall ports if firewalld is installed...')
+  run_task(workshop_deploy::setup_control_repo, $nodes, 'Setting up Control Repo...', 'username' => $github_user, 'password' => $github_pwd, '_run_as' => 'root')
 
-  upload_file('workshop_deploy/license.enc', '/etc/puppetlabs/license.enc', $nodes, 'Upload encrypted license key...')
-  run_task(workshop_deploy::decode_files, $nodes, 'Decoding encrypted files...')
+  run_task(workshop_deploy::firewall_ports, $nodes, 'Open firewall ports if firewalld is installed...', '_run_as' => 'root')
+
+  upload_file('workshop_deploy/license.enc', '/etc/puppetlabs/license.enc', $nodes, 'Upload encrypted license key...', '_run_as' => 'root')
+  run_task(workshop_deploy::decode_files, $nodes, 'Decoding encrypted files...', '_run_as' => 'root')
 
   notice('Securing key files...')
-  apply($nodes){
+  apply($nodes, '_run_as' => 'root'){
     file { '/etc/puppetlabs/puppetserver/ssh/id-control_repo.rsa':
       mode => '0600',
     }
@@ -110,16 +110,16 @@ plan workshop_deploy(
     }
   }
 
-  upload_file('workshop_deploy/csr_attributes.yaml', '/etc/puppetlabs/puppet/csr_attributes.yaml', $nodes, 'Upload CSR attributes file...')
+  upload_file('workshop_deploy/csr_attributes.yaml', '/etc/puppetlabs/puppet/csr_attributes.yaml', $nodes, 'Upload CSR attributes file...', '_run_as' => 'root')
 
-  run_task(workshop_deploy::install_pe, $nodes, 'Install latest version of Puppet Enterprise...', 'username' => $github_user, 'admin_pwd' => $pe_admin_pwd)
-  run_task(workshop_deploy::configure_autosign, $nodes, 'Configure Autosigning...')
+  run_task(workshop_deploy::install_pe, $nodes, 'Install latest version of Puppet Enterprise...', 'username' => $github_user, 'admin_pwd' => $pe_admin_pwd, '_run_as' => 'root')
+  run_task(workshop_deploy::configure_autosign, $nodes, 'Configure Autosigning...', '_run_as' => 'root')
 
-  run_command('chown -R pe-puppet:pe-puppet /etc/puppetlabs/puppetserver/ssh', $nodes, 'Set file ownership...')
-  run_command('/opt/puppetlabs/bin/puppet agent --onetime --no-daemonize --no-splay --no-usecacheonfailure --verbose', $nodes, 'Run Puppet Agent to complete installation...')
+  run_command('chown -R pe-puppet:pe-puppet /etc/puppetlabs/puppetserver/ssh', $nodes, 'Set file ownership...', '_run_as' => 'root')
+  run_command('/opt/puppetlabs/bin/puppet agent --onetime --no-daemonize --no-splay --no-usecacheonfailure --verbose', $nodes, 'Run Puppet Agent to complete installation...', '_run_as' => 'root')
 
   notice('Installing Puppet Bolt...')
-  apply($nodes){
+  apply($nodes, '_run_as' => 'root'){
     yumrepo { 'puppet6':
       ensure   => 'present',
       name     => 'puppet6',
@@ -136,14 +136,14 @@ plan workshop_deploy(
     }
   }
 
-  run_task(workshop_deploy::generate_token, $nodes, 'Generate RBAC Token...', 'admin_pwd' => $pe_admin_pwd)
-  run_command('/opt/puppetlabs/bin/puppet-code deploy production --wait', $nodes, 'Deploy latest Puppet code...')
+  run_task(workshop_deploy::generate_token, $nodes, 'Generate RBAC Token...', 'admin_pwd' => $pe_admin_pwd, '_run_as' => 'root')
+  run_command('/opt/puppetlabs/bin/puppet-code deploy production --wait', $nodes, 'Deploy latest Puppet code...', '_run_as' => 'root')
 
-  run_task(workshop_deploy::update_classes, $nodes, 'Update classes...', 'environment' => 'production')
-  run_task(workshop_deploy::create_nodegroup, $nodes, 'Creating Workshop node group...', 'master' => $pe_name)
-  run_command('/opt/puppetlabs/bin/puppet agent --onetime --no-daemonize --no-splay --no-usecacheonfailure --verbose', $nodes, 'Run Puppet Agent to apply classification changes...')
+  run_task(workshop_deploy::update_classes, $nodes, 'Update classes...', 'environment' => 'production', '_run_as' => 'root')
+  run_task(workshop_deploy::create_nodegroup, $nodes, 'Creating Workshop node group...', 'master' => $pe_name, '_run_as' => 'root')
+  run_command('/opt/puppetlabs/bin/puppet agent --onetime --no-daemonize --no-splay --no-usecacheonfailure --verbose', $nodes, 'Run Puppet Agent to apply classification changes...', '_run_as' => 'root')
 
-  run_task(workshop_deploy::create_webhook_to_aws, $nodes, 'Creating Webhook...', 'username' => $github_user, 'password' => $github_pwd)
+  run_task(workshop_deploy::create_webhook_to_aws, $nodes, 'Creating Webhook...', 'username' => $github_user, 'password' => $github_pwd, '_run_as' => 'root')
 
   notice("Installation complete, you can login to PE with username 'admin' and password '${pe_admin_pwd}'")
 }

--- a/plans/init.pp
+++ b/plans/init.pp
@@ -11,11 +11,13 @@ plan workshop_deploy(
   # Check for Bolt version, as behavior has changed with 1.16, now requiring the user to NOT specify '--run-as root' when calling the plan
   # This change makes the plan incompatible with 1.15 and earlier, so we need to fail the plan if that is the case.
   $r = run_task(workshop_deploy::check_bolt_version, 'localhost', 'Checking version of Bolt...', '_catch_errors' => true)
-  case $r.first.error.kind {
-    'puppetlabs.tasks/escalate-error': {
-      fail('You need to run this plan without the --run-as root option now!')
+  unless $r.ok {
+    case $r.first.error.kind {
+      'puppetlabs.tasks/escalate-error': {
+        fail('You need to run this plan without the --run-as root option now!')
+      }
+      default: { fail('You need to be running at least Bolt 1.16.0 to run this plan!') }
     }
-    default: { fail('You need to be running at least Bolt 1.16.0 to run this plan!') }
   }
 
   if $bastion == false {

--- a/plans/init.pp
+++ b/plans/init.pp
@@ -10,7 +10,7 @@ plan workshop_deploy(
 ) {
   # Check for Bolt version, as behavior has changed with 1.16, now requiring the user to NOT specify '--run-as root' when calling the plan
   # This change makes the plan incompatible with 1.15 and earlier, so we need to fail the plan if that is the case.
-  $r = run_task('workshop_deploy/check_bolt_version.sh', 'localhost', 'Checking version of Bolt...', '_catch_errors' => true)
+  $r = run_task(workshop_deploy::check_bolt_version, 'localhost', 'Checking version of Bolt...', '_catch_errors' => true)
   unless $r.ok {
     fail('You need to be running at least Bolt 1.16.0 to run this plan!')
   }

--- a/plans/init.pp
+++ b/plans/init.pp
@@ -11,11 +11,11 @@ plan workshop_deploy(
   # Check for Bolt version, as behavior has changed with 1.16, now requiring the user to NOT specify '--run-as root' when calling the plan
   # This change makes the plan incompatible with 1.15 and earlier, so we need to fail the plan if that is the case.
   $r = run_task(workshop_deploy::check_bolt_version, 'localhost', 'Checking version of Bolt...', '_catch_errors' => true)
-  case $r {
-    Error['puppetlabs.tasks/escalate-error'] : {
-      fail('You need to run this plan without the "--run-as root" option now!')
+  case $r.first.error.kind {
+    'puppetlabs.tasks/escalate-error': {
+      fail('You need to run this plan without the --run-as root option now!')
     }
-    Error : { fail('You need to be running at least Bolt 1.16.0 to run this plan!') }
+    default: { fail('You need to be running at least Bolt 1.16.0 to run this plan!') }
   }
 
   if $bastion == false {

--- a/plans/init.pp
+++ b/plans/init.pp
@@ -11,18 +11,18 @@ plan workshop_deploy(
   # Check for Bolt version, as behavior has changed with 1.16, now requiring the user to NOT specify '--run-as root' when calling the plan
   # This change makes the plan incompatible with 1.15 and earlier, so we need to fail the plan if that is the case.
   $r = run_task(workshop_deploy::check_bolt_version, 'localhost', 'Checking version of Bolt...', '_catch_errors' => true)
-  unless $r.ok {
-    fail('You need to be running at least Bolt 1.16.0 to run this plan!')
+  case $r {
+    Error['puppetlabs.tasks/escalate-error'] : {
+      fail('You need to run this plan without the "--run-as root" option now!')
+    }
+    Error : { fail('You need to be running at least Bolt 1.16.0 to run this plan!') }
   }
 
   if $bastion == false {
     notice('Info: Not using the Bastion account for AWS.')
     notice("Info: Using AWS region: ${awsregion}")
     notice("Info: Using AWS user: ${awsuser}")
-    $r = run_task(workshop_deploy::awskit_ensure_prereqs, 'localhost', 'Ensuring AWSkit prereqs are met... ' )
-    if $r.error.kind == 'puppetlabs.tasks/escalate-error' {
-      fail('You need to run this plan without the "--run-as root" option now!')
-    }
+    run_task(workshop_deploy::awskit_ensure_prereqs, 'localhost', 'Ensuring AWSkit prereqs are met... ' )
     run_script('workshop_deploy/awskit_deploy_master.sh', 'localhost', 'Deploy workshop PE Master on AWS using AWSKit... ', 'arguments' => [ "bastion=${bastion}", "awsregion=${awsregion}", "awsuser=${awsuser}" ] )
   }
   elsif $bastion == true {

--- a/plans/targets.pp
+++ b/plans/targets.pp
@@ -7,12 +7,15 @@ plan workshop_deploy::targets(
   # Check for Bolt version, as behavior has changed with 1.16, now requiring the user to NOT specify '--run-as root' when calling the plan
   # This change makes the plan incompatible with 1.15 and earlier, so we need to fail the plan if that is the case.
   $r = run_task(workshop_deploy::check_bolt_version, 'localhost', 'Checking version of Bolt...', '_catch_errors' => true)
-  case $r.first.error.kind {
-    'puppetlabs.tasks/escalate-error': {
-      fail('You need to run this plan without the --run-as root option now!')
+  unless $r.ok {
+    case $r.first.error.kind {
+      'puppetlabs.tasks/escalate-error': {
+        fail('You need to run this plan without the --run-as root option now!')
+      }
+      default: { fail('You need to be running at least Bolt 1.16.0 to run this plan!') }
     }
-    default: { fail('You need to be running at least Bolt 1.16.0 to run this plan!') }
   }
+
 
   if $bastion == false {
     notice('Info: Not using the Bastion account for AWS.')

--- a/plans/targets.pp
+++ b/plans/targets.pp
@@ -4,6 +4,16 @@ plan workshop_deploy::targets(
   String $awsuser,
   Integer $amount,
 ) {
+  # Check for Bolt version, as behavior has changed with 1.16, now requiring the user to NOT specify '--run-as root' when calling the plan
+  # This change makes the plan incompatible with 1.15 and earlier, so we need to fail the plan if that is the case.
+  $r = run_task(workshop_deploy::check_bolt_version, 'localhost', 'Checking version of Bolt...', '_catch_errors' => true)
+  case $r.first.error.kind {
+    'puppetlabs.tasks/escalate-error': {
+      fail('You need to run this plan without the --run-as root option now!')
+    }
+    default: { fail('You need to be running at least Bolt 1.16.0 to run this plan!') }
+  }
+
   if $bastion == false {
     notice('Info: Not using the Bastion account for AWS.')
     notice("Info: Using AWS region: ${awsregion}")

--- a/tasks/check_bolt_version.sh
+++ b/tasks/check_bolt_version.sh
@@ -1,0 +1,10 @@
+version=$(bolt --version)
+major=`echo $version | cut -d. -f1`
+minor=`echo $version | cut -d. -f2`
+revision=`echo $version | cut -d. -f3`
+
+if [ $major -ge 1 ] && [ $minor -ge 16 ]; then
+    exit 0
+else
+    exit 1
+fi

--- a/tasks/check_bolt_version.sh
+++ b/tasks/check_bolt_version.sh
@@ -1,4 +1,4 @@
-version=$(bolt --version)
+version=$(/opt/puppetlabs/bin/bolt --version)
 major=`echo $version | cut -d. -f1`
 minor=`echo $version | cut -d. -f2`
 revision=`echo $version | cut -d. -f3`


### PR DESCRIPTION
This update supports Bolt 1.16 and validates for this version being installed.
It will fail the plan if an older version of Bolt is installing, telling the user to upgrade.

The `--run-as root` option should now no longer be used on the command line, as it will result in an escalation error for the actions on `localhost`. The plan now checks for this error type and notifies the user to remove `--run-as root` from the command line.